### PR TITLE
add location schema & related files, implement node module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.DS_Store
+node_modules
+tmp
+*.log*

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,9 @@
+The MIT License (MIT)
+
+Copyright (c) 2015 OpenAQ
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,2 @@
+# Schemas
+- [Location](./location.md)

--- a/docs/location.md
+++ b/docs/location.md
@@ -16,7 +16,6 @@ Schema defining metadata for OpenAQ locations
 |----------|------|----------|----------|------------|
 | [activationDate](#activationdate) | `string` | Optional  | No | Location (this schema) |
 | [active](#active) | `boolean` | Optional  | No | Location (this schema) |
-| [altitude](#altitude) | `integer` | Optional  | No | Location (this schema) |
 | [attribution](#attribution) | `object[]` | Optional  | No | Location (this schema) |
 | [city](#city) | `string` | Optional  | No | Location (this schema) |
 | [coordinates](#coordinates) | `object` | Optional  | No | Location (this schema) |
@@ -26,7 +25,6 @@ Schema defining metadata for OpenAQ locations
 | [instruments](#instruments) | `object[]` | **Required**  | No | Location (this schema) |
 | [name](#name) | `string` | **Required**  | No | Location (this schema) |
 | [notes](#notes) | `string` | Optional  | No | Location (this schema) |
-| [pollutants](#pollutants) | `enum[]` | Optional  | No | Location (this schema) |
 | [siteType](#sitetype) | `enum` | Optional  | No | Location (this schema) |
 | [sourceType](#sourcetype) | `enum` | Optional  | No | Location (this schema) |
 | `*` | any | Additional | Yes | this schema *allows* additional properties |
@@ -68,28 +66,6 @@ Whether the location is currently active
 
 
 `boolean`
-
-
-
-
-
-## altitude
-### Altitude
-
-The altitude of the location in meters
-
-`altitude`
-
-* is optional
-* type: `integer`
-* defined in this schema
-
-### altitude Type
-
-
-`integer`
-
-
 
 
 
@@ -380,7 +356,7 @@ All items must be of the type:
 | `measurementStyle`| string | Optional |
 | `modelName`| string | Optional |
 | `notes`| string | Optional |
-| `pollutants`| array | **Required** |
+| `parameters`| array | **Required** |
 | `rawFrequency`| integer | Optional |
 | `reportingFrequency`| integer | Optional |
 | `serialNumber`| string | **Required** |
@@ -594,18 +570,18 @@ Any relevant notes about the instrument
 
 
 
-#### pollutants
-##### Pollutants
+#### parameters
+##### Parameters
 
 Pollutants measured by this instrument
 
-`pollutants`
+`parameters`
 
 * is **required**
 * type: `enum[]`
 
 
-##### pollutants Type
+##### parameters Type
 
 
 Array type: `enum[]`
@@ -759,34 +735,6 @@ Any relevant notes about the location
 
 
 `string`
-
-
-
-
-
-
-
-## pollutants
-### Pollutants
-
-Pollutants measured at a location
-
-`pollutants`
-
-* is optional
-* type: `enum[]`
-* defined in this schema
-
-### pollutants Type
-
-
-Array type: `enum[]`
-
-All items must be of the type:
-`string`
-
-
-
 
 
 

--- a/docs/location.md
+++ b/docs/location.md
@@ -1,0 +1,823 @@
+
+# Location Schema
+
+```
+```
+
+Schema defining metadata for OpenAQ locations
+
+| Abstract | Extensible | Status | Identifiable | Custom Properties | Additional Properties | Defined In |
+|----------|------------|--------|--------------|-------------------|-----------------------|------------|
+| Can be instantiated | No | Experimental | No | Forbidden | Permitted | [location.json](location.json) |
+
+# Location Properties
+
+| Property | Type | Required | Nullable | Defined by |
+|----------|------|----------|----------|------------|
+| [activationDate](#activationdate) | `string` | Optional  | No | Location (this schema) |
+| [active](#active) | `boolean` | Optional  | No | Location (this schema) |
+| [altitude](#altitude) | `integer` | Optional  | No | Location (this schema) |
+| [attribution](#attribution) | `object[]` | Optional  | No | Location (this schema) |
+| [city](#city) | `string` | Optional  | No | Location (this schema) |
+| [coordinates](#coordinates) | `object` | Optional  | No | Location (this schema) |
+| [country](#country) | `string` | Optional  | No | Location (this schema) |
+| [deactivationDate](#deactivationdate) | `string` | Optional  | No | Location (this schema) |
+| [id](#id) | `string` | **Required**  | No | Location (this schema) |
+| [instruments](#instruments) | `object[]` | **Required**  | No | Location (this schema) |
+| [name](#name) | `string` | **Required**  | No | Location (this schema) |
+| [notes](#notes) | `string` | Optional  | No | Location (this schema) |
+| [pollutants](#pollutants) | `enum[]` | Optional  | No | Location (this schema) |
+| [sourceType](#sourcetype) | `enum` | Optional  | No | Location (this schema) |
+| `*` | any | Additional | Yes | this schema *allows* additional properties |
+
+## activationDate
+### Activation date
+
+Date the instruments were activated at this location, stored as an ISO timestamp
+
+`activationDate`
+
+* is optional
+* type: `string`
+* defined in this schema
+
+### activationDate Type
+
+
+`string`
+
+
+
+
+
+
+
+## active
+### Active
+
+Whether the location is currently active
+
+`active`
+
+* is optional
+* type: `boolean`
+* defined in this schema
+
+### active Type
+
+
+`boolean`
+
+
+
+
+
+## altitude
+### Altitude
+
+The altitude of the location in meters
+
+`altitude`
+
+* is optional
+* type: `integer`
+* defined in this schema
+
+### altitude Type
+
+
+`integer`
+
+
+
+
+
+
+
+## attribution
+### Attributions
+
+Data attribution in descending order of prominence
+
+`attribution`
+
+* is optional
+* type: `object[]`
+* defined in this schema
+
+### attribution Type
+
+
+Array type: `object[]`
+
+All items must be of the type:
+`object` with following properties:
+
+
+| Property | Type | Required |
+|----------|------|----------|
+| `name`| string | Optional |
+| `url`| string | Optional |
+
+
+
+#### name
+##### Attribution Name
+
+
+`name`
+
+* is optional
+* type: `string`
+
+##### name Type
+
+
+`string`
+
+
+
+
+
+
+
+
+
+#### url
+##### Attribution Url
+
+
+`url`
+
+* is optional
+* type: `string`
+
+##### url Type
+
+
+`string`
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+## city
+### City
+
+The city of the location
+
+`city`
+
+* is optional
+* type: `string`
+* defined in this schema
+
+### city Type
+
+
+`string`
+
+
+
+
+
+
+### city Example
+
+```json
+"Seattle"
+```
+
+
+## coordinates
+### Coordinates
+
+Lat/Lon coordinates
+
+`coordinates`
+
+* is optional
+* type: `object`
+* defined in this schema
+
+### coordinates Type
+
+
+`object` with following properties:
+
+
+| Property | Type | Required |
+|----------|------|----------|
+| `latitude`| number | **Required** |
+| `longitude`| number | **Required** |
+
+
+
+#### latitude
+##### Latitude
+
+
+`latitude`
+
+* is **required**
+* type: `number`
+
+##### latitude Type
+
+
+`number`
+
+
+
+
+
+
+
+
+
+#### longitude
+##### Longitude
+
+
+`longitude`
+
+* is **required**
+* type: `number`
+
+##### longitude Type
+
+
+`number`
+
+
+
+
+
+
+
+
+
+
+
+
+## country
+### Country
+
+The country of the location
+
+`country`
+
+* is optional
+* type: `string`
+* defined in this schema
+
+### country Type
+
+
+`string`
+
+
+
+
+
+
+### country Example
+
+```json
+"US"
+```
+
+
+## deactivationDate
+### Deactivation date
+
+Date the instruments were deactivated at this location, stored as an ISO timestamp
+
+`deactivationDate`
+
+* is optional
+* type: `string`
+* defined in this schema
+
+### deactivationDate Type
+
+
+`string`
+
+
+
+
+
+
+
+## id
+### ID
+
+ID for a location
+
+`id`
+
+* is **required**
+* type: `string`
+* defined in this schema
+
+### id Type
+
+
+`string`
+
+
+
+All instances must conform to this regular expression 
+```regex
+^(.*)$
+```
+
+
+
+
+
+
+## instruments
+### Instruments
+
+An array of instruments installed at this location
+
+`instruments`
+
+* is **required**
+* type: `object[]`
+* defined in this schema
+
+### instruments Type
+
+
+Array type: `object[]`
+
+All items must be of the type:
+`object` with following properties:
+
+
+| Property | Type | Required |
+|----------|------|----------|
+| `activationDate`| string | Optional |
+| `active`| boolean | Optional |
+| `calibrationProcedures`| string | Optional |
+| `deactivationDate`| string | Optional |
+| `inletHeight`| integer | Optional |
+| `manufacturer`| string | Optional |
+| `measurementStyle`| string | Optional |
+| `modelName`| string | Optional |
+| `notes`| string | Optional |
+| `pollutants`| array | **Required** |
+| `rawFrequency`| integer | Optional |
+| `reportingFrequency`| integer | Optional |
+| `serialNumber`| string | **Required** |
+| `type`| string | **Required** |
+
+
+
+#### activationDate
+##### Instrument activation date
+
+Date the instrument was activated at this location, stored as an ISO timestamp
+
+`activationDate`
+
+* is optional
+* type: `string`
+
+##### activationDate Type
+
+
+`string`
+
+
+
+
+
+
+
+
+
+#### active
+##### Active
+
+Whether the location is currently active
+
+`active`
+
+* is optional
+* type: `boolean`
+
+##### active Type
+
+
+`boolean`
+
+
+
+
+
+
+
+#### calibrationProcedures
+##### Calibration procedures
+
+Instrument-specific calibration procedures
+
+`calibrationProcedures`
+
+* is optional
+* type: `string`
+
+##### calibrationProcedures Type
+
+
+`string`
+
+
+
+
+
+
+
+
+
+#### deactivationDate
+##### Instrument deactivation date
+
+Date the instrument was deactivated at this location, stored as an ISO timestamp
+
+`deactivationDate`
+
+* is optional
+* type: `string`
+
+##### deactivationDate Type
+
+
+`string`
+
+
+
+
+
+
+
+
+
+#### inletHeight
+##### Inlet height
+
+Height of intake inlet in meters
+
+`inletHeight`
+
+* is optional
+* type: `integer`
+
+##### inletHeight Type
+
+
+`integer`
+
+
+
+
+
+
+
+
+
+#### manufacturer
+##### Manufacturer
+
+Manufacturer of the instrument
+
+`manufacturer`
+
+* is optional
+* type: `string`
+
+##### manufacturer Type
+
+
+`string`
+
+
+
+
+
+
+
+
+
+#### measurementStyle
+##### Measurement style
+
+How measurements are taken
+
+`measurementStyle`
+
+* is optional
+* type: `enum`
+
+The value of this property **must** be equal to one of the [known values below](#instruments-known-values).
+
+##### measurementStyle Known Values
+| Value | Description |
+|-------|-------------|
+| `automated` |  |
+| `manual` |  |
+| `unknown` |  |
+
+
+
+
+
+
+#### modelName
+##### Model name
+
+Model name of the instrument
+
+`modelName`
+
+* is optional
+* type: `string`
+
+##### modelName Type
+
+
+`string`
+
+
+
+
+
+
+
+
+
+#### notes
+##### Notes
+
+Any relevant notes about the instrument
+
+`notes`
+
+* is optional
+* type: `string`
+
+##### notes Type
+
+
+`string`
+
+
+
+
+
+
+
+
+
+#### pollutants
+##### Pollutants
+
+Pollutants measured by this instrument
+
+`pollutants`
+
+* is **required**
+* type: `enum[]`
+
+
+##### pollutants Type
+
+
+Array type: `enum[]`
+
+All items must be of the type:
+`string`
+
+
+
+
+
+
+
+
+
+
+
+
+#### rawFrequency
+##### Raw frequency
+
+The raw sampling frequency of the instrument in milliseconds
+
+`rawFrequency`
+
+* is optional
+* type: `integer`
+
+##### rawFrequency Type
+
+
+`integer`
+
+
+
+
+
+
+
+
+
+#### reportingFrequency
+##### Reporting frequency
+
+The reporting sampling frequency of the instrument in milliseconds
+
+`reportingFrequency`
+
+* is optional
+* type: `integer`
+
+##### reportingFrequency Type
+
+
+`integer`
+
+
+
+
+
+
+
+
+
+#### serialNumber
+##### Serial number
+
+Serial number of the instrument
+
+`serialNumber`
+
+* is **required**
+* type: `string`
+
+##### serialNumber Type
+
+
+`string`
+
+
+
+
+
+
+
+
+
+#### type
+##### Type
+
+The type of instrument
+
+`type`
+
+* is **required**
+* type: `string`
+
+##### type Type
+
+
+`string`
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+## name
+### Name
+
+Name of a location
+
+`name`
+
+* is **required**
+* type: `string`
+* defined in this schema
+
+### name Type
+
+
+`string`
+
+
+
+
+
+
+
+## notes
+### Notes
+
+Any relevant notes about the location
+
+`notes`
+
+* is optional
+* type: `string`
+* defined in this schema
+
+### notes Type
+
+
+`string`
+
+
+
+
+
+
+
+## pollutants
+### Pollutants
+
+Pollutants measured at a location
+
+`pollutants`
+
+* is optional
+* type: `enum[]`
+* defined in this schema
+
+### pollutants Type
+
+
+Array type: `enum[]`
+
+All items must be of the type:
+`string`
+
+
+
+
+
+
+
+
+
+
+## sourceType
+### Source type
+
+The source of the instruments at the location. Government instruments are deployed by or on behalf of governmental bodies. Research instruments are deployed by researchers affiliated with universities and/or research organizations. Other instruments are deployed by citizen scientists, often low-cost instruments
+
+`sourceType`
+
+* is optional
+* type: `enum`
+* defined in this schema
+
+The value of this property **must** be equal to one of the [known values below](#sourcetype-known-values).
+
+### sourceType Known Values
+| Value | Description |
+|-------|-------------|
+| `government` |  |
+| `research` |  |
+| `other` |  |
+
+
+
+### sourceType Example
+
+```json
+"government"
+```
+

--- a/docs/location.md
+++ b/docs/location.md
@@ -27,6 +27,7 @@ Schema defining metadata for OpenAQ locations
 | [name](#name) | `string` | **Required**  | No | Location (this schema) |
 | [notes](#notes) | `string` | Optional  | No | Location (this schema) |
 | [pollutants](#pollutants) | `enum[]` | Optional  | No | Location (this schema) |
+| [siteType](#sitetype) | `enum` | Optional  | No | Location (this schema) |
 | [sourceType](#sourcetype) | `enum` | Optional  | No | Location (this schema) |
 | `*` | any | Additional | Yes | this schema *allows* additional properties |
 
@@ -791,6 +792,36 @@ All items must be of the type:
 
 
 
+
+
+## siteType
+### Site type
+
+The type of area the location is in. Government instruments are deployed by or on behalf of governmental bodies. Research instruments are deployed by researchers affiliated with universities and/or research organizations. Other instruments are deployed by citizen scientists, often low-cost instruments
+
+`siteType`
+
+* is optional
+* type: `enum`
+* defined in this schema
+
+The value of this property **must** be equal to one of the [known values below](#sitetype-known-values).
+
+### siteType Known Values
+| Value | Description |
+|-------|-------------|
+| `rural` |  |
+| `urban` |  |
+| `suburban` |  |
+| `other` |  |
+
+
+
+### siteType Example
+
+```json
+"urban"
+```
 
 
 ## sourceType

--- a/docs/location.md
+++ b/docs/location.md
@@ -45,6 +45,7 @@ Date the instruments were activated at this location, stored as an ISO timestamp
 
 `string`
 
+* format: `date-time` – date and time (according to [RFC 3339, section 5.6](http://tools.ietf.org/html/rfc3339))
 
 
 
@@ -291,6 +292,7 @@ Date the instruments were deactivated at this location, stored as an ISO timesta
 
 `string`
 
+* format: `date-time` – date and time (according to [RFC 3339, section 5.6](http://tools.ietf.org/html/rfc3339))
 
 
 
@@ -379,6 +381,7 @@ Date the instrument was activated at this location, stored as an ISO timestamp
 
 `string`
 
+* format: `date-time` – date and time (according to [RFC 3339, section 5.6](http://tools.ietf.org/html/rfc3339))
 
 
 
@@ -446,6 +449,7 @@ Date the instrument was deactivated at this location, stored as an ISO timestamp
 
 `string`
 
+* format: `date-time` – date and time (according to [RFC 3339, section 5.6](http://tools.ietf.org/html/rfc3339))
 
 
 

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 const Ajv = require('ajv');
+const jsonschema = require('jsonschema');
 const location = require('./schemas/location');
 
 const schemas = { location };
@@ -10,9 +11,7 @@ function validate (schemaName, data, options) {
     throw new Error('Schema not found');
   }
 
-  const ajv = new Ajv(options);
-  const validate = ajv.compile(schema);
-  return validate(data);
+  return jsonschema.validate(data, schema, options);
 }
 
 module.exports = {

--- a/index.js
+++ b/index.js
@@ -1,0 +1,21 @@
+const Ajv = require('ajv');
+const location = require('./schemas/location');
+
+const schemas = { location };
+
+function validate (schemaName, data, options) {
+  const schema = schemas[schemaName];
+
+  if (!schema) {
+    throw new Error('Schema not found');
+  }
+
+  const ajv = new Ajv(options);
+  const validate = ajv.compile(schema);
+  return validate(data);
+}
+
+module.exports = {
+  validate,
+  schemas
+};

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "homepage": "https://github.com/openaq/openaq-data-format#readme",
   "dependencies": {
-    "ajv": "^6.10.0"
+    "jsonschema": "^1.2.4"
   },
   "devDependencies": {
     "@adobe/jsonschema2md": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "openaq-data-format",
+  "version": "0.0.0",
+  "description": "schema and documentation of openaq data",
+  "main": "index.js",
+  "scripts": {
+    "build": "jsonschema2md -d schemas -o docs -n --schema-out=- -e json"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/openaq/openaq-data-format.git"
+  },
+  "keywords": [
+    "openaq"
+  ],
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/openaq/openaq-data-format/issues"
+  },
+  "homepage": "https://github.com/openaq/openaq-data-format#readme",
+  "dependencies": {
+    "ajv": "^6.10.0"
+  },
+  "devDependencies": {
+    "@adobe/jsonschema2md": "^2.0.0"
+  }
+}

--- a/schemas/location.json
+++ b/schemas/location.json
@@ -20,9 +20,9 @@
       "title": "Name",
       "description": "Name of a location"
     },
-    "pollutants": {
+    "parameters": {
       "type": "array",
-      "title": "Pollutants",
+      "title": "Parameters",
       "description": "Pollutants measured at a location",
       "items": {
         "type": "string",
@@ -138,7 +138,7 @@
         "required": [
           "type",
           "serialNumber",
-          "pollutants"
+          "parameters"
         ],
         "properties": {
           "type": {
@@ -161,9 +161,9 @@
             "title": "Model name",
             "description": "Model name of the instrument"
           },
-          "pollutants": {
+          "parameters": {
             "type": "array",
-            "title": "Pollutants",
+            "title": "Parameters",
             "description": "Pollutants measured by this instrument",
             "items": {
               "type": "string",

--- a/schemas/location.json
+++ b/schemas/location.json
@@ -18,7 +18,8 @@
     "name": {
       "type": "string",
       "title": "Name",
-      "description": "Name of a location"
+      "description": "Name of a location",
+      "minLength": 1
     },
     "city": {
       "type": "string",
@@ -121,6 +122,7 @@
       "items": {
         "type": "object",
         "title": "Instrument",
+        "minItems": 1,
         "required": [
           "type",
           "serialNumber",
@@ -130,12 +132,14 @@
           "type": {
             "type": "string",
             "title": "Type",
-            "description": "The type of instrument"
+            "description": "The type of instrument",
+            "minLength": 1,
           },
           "serialNumber": {
             "type": "string",
             "title": "Serial number",
-            "description": "Serial number of the instrument"
+            "description": "Serial number of the instrument",
+            "minLength": 1,
           },
           "manufacturer": {
             "type": "string",
@@ -151,6 +155,7 @@
             "type": "array",
             "title": "Parameters",
             "description": "Pollutants measured by this instrument",
+            "minItems": 1,
             "items": {
               "type": "string",
               "title": "Pollutant type",

--- a/schemas/location.json
+++ b/schemas/location.json
@@ -52,6 +52,15 @@
       "description": "The altitude of the location in meters",
       "examples": []
     },
+    "siteType": {
+      "type": "string",
+      "title": "Site type",
+      "description": "The type of area the location is in. Government instruments are deployed by or on behalf of governmental bodies. Research instruments are deployed by researchers affiliated with universities and/or research organizations. Other instruments are deployed by citizen scientists, often low-cost instruments",
+      "examples": [
+        "urban"
+      ],
+      "enum": ["rural", "urban", "suburban", "other"]
+    },
     "sourceType": {
       "type": "string",
       "title": "Source type",

--- a/schemas/location.json
+++ b/schemas/location.json
@@ -20,16 +20,6 @@
       "title": "Name",
       "description": "Name of a location"
     },
-    "parameters": {
-      "type": "array",
-      "title": "Parameters",
-      "description": "Pollutants measured at a location",
-      "items": {
-        "type": "string",
-        "title": "Pollutant type",
-        "enum": ["pm25", "pm10", "co", "bc", "so2", "no2", "o3"]
-      }
-    },
     "city": {
       "type": "string",
       "title": "City",
@@ -45,12 +35,6 @@
       "examples": [
         "US"
       ]
-    },
-    "altitude": {
-      "type": "integer",
-      "title": "Altitude",
-      "description": "The altitude of the location in meters",
-      "examples": []
     },
     "siteType": {
       "type": "string",

--- a/schemas/location.json
+++ b/schemas/location.json
@@ -75,11 +75,13 @@
     },
     "activationDate": {
       "type": "string",
+      "format": "date-time",
       "title": "Activation date",
       "description": "Date the instruments were activated at this location, stored as an ISO timestamp"
     },
     "deactivationDate": {
       "type": "string",
+      "format": "date-time",
       "title": "Deactivation date",
       "description": "Date the instruments were deactivated at this location, stored as an ISO timestamp"
     },
@@ -183,11 +185,13 @@
           },
           "activationDate": {
             "type": "string",
+            "format": "date-time",
             "title": "Instrument activation date",
             "description": "Date the instrument was activated at this location, stored as an ISO timestamp"
           },
           "deactivationDate": {
             "type": "string",
+            "format": "date-time",
             "title": "Instrument deactivation date",
             "description": "Date the instrument was deactivated at this location, stored as an ISO timestamp"
           },

--- a/schemas/location.json
+++ b/schemas/location.json
@@ -1,0 +1,215 @@
+{
+  "type": "object",
+  "title": "Location",
+  "description": "Schema defining metadata for OpenAQ locations",
+  "required": [
+    "id",
+    "name",
+    "instruments"
+  ],
+  "properties": {
+    "id": {
+      "type": "string",
+      "title": "ID",
+      "description": "ID for a location",
+      "examples": [],
+      "pattern": "^(.*)$"
+    },
+    "name": {
+      "type": "string",
+      "title": "Name",
+      "description": "Name of a location"
+    },
+    "pollutants": {
+      "type": "array",
+      "title": "Pollutants",
+      "description": "Pollutants measured at a location",
+      "items": {
+        "type": "string",
+        "title": "Pollutant type",
+        "enum": ["pm25", "pm10", "co", "bc", "so2", "no2", "o3"]
+      }
+    },
+    "city": {
+      "type": "string",
+      "title": "City",
+      "description": "The city of the location",
+      "examples": [
+        "Seattle"
+      ]
+    },
+    "country": {
+      "type": "string",
+      "title": "Country",
+      "description": "The country of the location",
+      "examples": [
+        "US"
+      ]
+    },
+    "altitude": {
+      "type": "integer",
+      "title": "Altitude",
+      "description": "The altitude of the location in meters",
+      "examples": []
+    },
+    "sourceType": {
+      "type": "string",
+      "title": "Source type",
+      "description": "The source of the instruments at the location. Government instruments are deployed by or on behalf of governmental bodies. Research instruments are deployed by researchers affiliated with universities and/or research organizations. Other instruments are deployed by citizen scientists, often low-cost instruments",
+      "examples": [
+        "government"
+      ],
+      "enum": ["government", "research", "other"]
+    },
+    "coordinates": {
+      "type": "object",
+      "title": "Coordinates",
+      "description": "Lat/Lon coordinates",
+      "required": [
+        "latitude",
+        "longitude"
+      ],
+      "properties": {
+        "latitude": {
+          "type": "number",
+          "title": "Latitude"
+        },
+        "longitude": {
+          "type": "number",
+          "title": "Longitude"
+        }
+      }
+    },
+    "activationDate": {
+      "type": "string",
+      "title": "Activation date",
+      "description": "Date the instruments were activated at this location, stored as an ISO timestamp"
+    },
+    "deactivationDate": {
+      "type": "string",
+      "title": "Deactivation date",
+      "description": "Date the instruments were deactivated at this location, stored as an ISO timestamp"
+    },
+    "active": {
+      "type": "boolean",
+      "title": "Active",
+      "description": "Whether the location is currently active"
+    },
+    "notes": {
+      "type": "string",
+      "title": "Notes",
+      "description": "Any relevant notes about the location"
+    },
+    "attribution": {
+      "type": "array",
+      "title": "Attributions",
+      "description": "Data attribution in descending order of prominence",
+      "items": {
+        "type": "object",
+        "title": "Attribution",
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Attribution Name"
+          },
+          "url": {
+            "type": "string",
+            "title": "Attribution Url"
+          }
+        }
+      }
+    },
+    "instruments": {
+      "type": "array",
+      "title": "Instruments",
+      "description": "An array of instruments installed at this location",
+      "items": {
+        "type": "object",
+        "title": "Instrument",
+        "required": [
+          "type",
+          "serialNumber",
+          "pollutants"
+        ],
+        "properties": {
+          "type": {
+            "type": "string",
+            "title": "Type",
+            "description": "The type of instrument"
+          },
+          "serialNumber": {
+            "type": "string",
+            "title": "Serial number",
+            "description": "Serial number of the instrument"
+          },
+          "manufacturer": {
+            "type": "string",
+            "title": "Manufacturer",
+            "description": "Manufacturer of the instrument"
+          },
+          "modelName": {
+            "type": "string",
+            "title": "Model name",
+            "description": "Model name of the instrument"
+          },
+          "pollutants": {
+            "type": "array",
+            "title": "Pollutants",
+            "description": "Pollutants measured by this instrument",
+            "items": {
+              "type": "string",
+              "title": "Pollutant type",
+              "enum": ["pm25", "pm10", "co", "bc", "so2", "no2", "o3"]
+            }
+          },
+          "rawFrequency": {
+            "type": "integer",
+            "title": "Raw frequency",
+            "description": "The raw sampling frequency of the instrument in milliseconds"
+          },
+          "reportingFrequency": {
+            "type": "integer",
+            "title": "Reporting frequency",
+            "description": "The reporting sampling frequency of the instrument in milliseconds"
+          },
+          "measurementStyle": {
+            "type": "string",
+            "title": "Measurement style",
+            "description": "How measurements are taken",
+            "enum": ["automated", "manual", "unknown"]
+          },
+          "calibrationProcedures": {
+            "type": "string",
+            "title": "Calibration procedures",
+            "description": "Instrument-specific calibration procedures"
+          },
+          "inletHeight": {
+            "type": "integer",
+            "title": "Inlet height",
+            "description": "Height of intake inlet in meters"
+          },
+          "activationDate": {
+            "type": "string",
+            "title": "Instrument activation date",
+            "description": "Date the instrument was activated at this location, stored as an ISO timestamp"
+          },
+          "deactivationDate": {
+            "type": "string",
+            "title": "Instrument deactivation date",
+            "description": "Date the instrument was deactivated at this location, stored as an ISO timestamp"
+          },
+          "active": {
+            "type": "boolean",
+            "title": "Active",
+            "description": "Whether the location is currently active"
+          },
+          "notes": {
+            "type": "string",
+            "title": "Notes",
+            "description": "Any relevant notes about the instrument"
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
This adds a json schema for locations & associated instruments, and includes initial implementation of a node module that exposes the location schema and a `validate` function. This will allow us to write tests against the schema and/or use the schema as a dependency for validating api requests, generating test data, etc.

The schema is based on discussion in https://github.com/openaq/project-metadata-format/issues/7, some editing may be needed.

I considered breaking the `instrument` schema out into its own file but it didn't seem like there was a use case for having it separate.

The docs in `docs/location.md` are generated by running `npm run build`.